### PR TITLE
Add `AutoModel`, `AutoConfig` and update Tainer tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         "tqdm",
         "typing_extensions",
         "dataclasses>=0.6",
-        "torchvision"
+        "torchvision",
     ],
     extras_require={':python_version == "3.7.*"': ["pickle5"]},
     python_requires=">=3.7",

--- a/src/multivae/data/__init__.py
+++ b/src/multivae/data/__init__.py
@@ -1,5 +1,3 @@
 from .datasets import MultimodalBaseDataset
 
-__all__ = [
-    "MultimodalBaseDataset"
-]
+__all__ = ["MultimodalBaseDataset"]

--- a/src/multivae/data/datasets/__init__.py
+++ b/src/multivae/data/datasets/__init__.py
@@ -1,5 +1,3 @@
 from .base import MultimodalBaseDataset
 
-__all__ = [
-    "MultimodalBaseDataset"
-]
+__all__ = ["MultimodalBaseDataset"]

--- a/src/multivae/data/datasets/base.py
+++ b/src/multivae/data/datasets/base.py
@@ -1,12 +1,10 @@
 from collections import OrderedDict
 from typing import Any, Tuple, Union
-from torch import Tensor
-from numpy import ndarray
 
 import torch
-
-from pythae.data.datasets import Dataset
-from pythae.data.datasets import DatasetOutput
+from numpy import ndarray
+from pythae.data.datasets import Dataset, DatasetOutput
+from torch import Tensor
 
 
 class MultimodalBaseDataset(Dataset):
@@ -15,26 +13,24 @@ class MultimodalBaseDataset(Dataset):
         A ``__getitem__`` is redefined and outputs a python dictionnary
     with the keys corresponding to `data` and `labels`.
     This Class should be used for any new data sets.
-    
+
     Args :
-        data (dict) : A dictionary containing the modalities' name and a tensor or numpy array for each modality. 
-        labels (Union[Tensor, ndarray]) : A torch.Tensor or numpy.ndarray instance containing the labels. 
+        data (dict) : A dictionary containing the modalities' name and a tensor or numpy array for each modality.
+        labels (Union[Tensor, ndarray]) : A torch.Tensor or numpy.ndarray instance containing the labels.
     """
 
-    def __init__(self, data : dict, labels : Union[Tensor,ndarray]):
-
+    def __init__(self, data: dict, labels: Union[Tensor, ndarray]):
         self.labels = labels
         self.data = data
 
     def __len__(self):
-        
         length = len(self.data[list(self.data)[0]])
         for m in self.data:
             if len(self.data[m]) != length:
                 raise AttributeError(
                     "The size of the provided datasets doesn't correspond between modalities!"
-                    )
-        
+                )
+
         return length
 
     def __getitem__(self, index):
@@ -48,7 +44,7 @@ class MultimodalBaseDataset(Dataset):
             torch.Tensor
         """
         # Select sample
-        X = {modality : self.data[modality][index] for modality in self.data }
+        X = {modality: self.data[modality][index] for modality in self.data}
         y = self.labels[index]
 
         return DatasetOutput(data=X, labels=y)

--- a/src/multivae/data/datasets/mnist_svhn.py
+++ b/src/multivae/data/datasets/mnist_svhn.py
@@ -1,78 +1,83 @@
-from .base import MultimodalBaseDataset
-from pathlib import Path
-from typing import Union
-from torchvision.datasets import MNIST, SVHN
-from .utils import ResampleDataset
-import torch
 import os
 from pathlib import Path
+from typing import Union
+
+import torch
+from torchvision.datasets import MNIST, SVHN
 from torchvision.transforms import ToTensor
+
+from .base import MultimodalBaseDataset
+from .utils import ResampleDataset
+
 
 class MnistSvhn(MultimodalBaseDataset):
     """
-    
+
     A paired MnistSvhn dataset.
-    
+
     Args:
-        path (str) : The path where the data is saved. 
+        path (str) : The path where the data is saved.
         split (str) : Either 'train' or 'test'.
         download (bool) : Whether to download the data or not. Default to True.
-        
+
         **kwargs:
-            
+
             transform_mnist (Transform) : a transformation to apply to MNIST. If none specified, a simple ToTensor() is applied.
             transform_svhn (Transform) : a transformation to apply to SVHN. If none specified, a simple ToTensor() is applied.
-            
+
     """
-    
-    
-    def __init__(self, data_path : Union[str, Path] = '../data/', split : str = 'train', download = True, **kwargs):
-        
-        if split not in ['train', 'test']:
-            raise AttributeError(
-                "Possible values for split are 'train' or 'test'"
-            )
-        
+
+    def __init__(
+        self,
+        data_path: Union[str, Path] = "../data/",
+        split: str = "train",
+        download=True,
+        **kwargs,
+    ):
+        if split not in ["train", "test"]:
+            raise AttributeError("Possible values for split are 'train' or 'test'")
+
         # Load unimodal datasets
         transform_mnist, transform_svhn = ToTensor(), ToTensor()
-        if 'transform_mnist' in kwargs:
-            transform_mnist = kwargs['transform_mnist']
-        if 'transform_svhn' in kwargs:
-            transform_svhn = kwargs['transform_svhn']
-        
-        
-        mnist = MNIST(data_path, train = (split == 'train'), download=download, transform=transform_mnist)
-        svhn = SVHN(data_path, split = split, download=download, transform=transform_svhn)
-        
+        if "transform_mnist" in kwargs:
+            transform_mnist = kwargs["transform_mnist"]
+        if "transform_svhn" in kwargs:
+            transform_svhn = kwargs["transform_svhn"]
+
+        mnist = MNIST(
+            data_path,
+            train=(split == "train"),
+            download=download,
+            transform=transform_mnist,
+        )
+        svhn = SVHN(data_path, split=split, download=download, transform=transform_svhn)
+
         # Check if a pairing already exists and if not create one
         if not self._check_pairing_exists(data_path, split):
             self.create_pairing(mnist, svhn, data_path)
-        
-        i_mnist = torch.load(data_path + '/mnist_svhn_idx/' + split +'/mnist_idx.pt')
-        i_svhn = torch.load(data_path + '/mnist_svhn_idx/' + split +'/svhn_idx.pt')
-                
+
+        i_mnist = torch.load(data_path + "/mnist_svhn_idx/" + split + "/mnist_idx.pt")
+        i_svhn = torch.load(data_path + "/mnist_svhn_idx/" + split + "/svhn_idx.pt")
+
         labels = mnist.targets[i_mnist]
-        
+
         # Resample the datasets
-        mnist = ResampleDataset(mnist, lambda d,i : i_mnist[i], size=len(i_mnist))
-        svhn = ResampleDataset(svhn, lambda d,i : i_svhn[i], size=len(i_svhn))
-        
-        data = dict(mnist = mnist, svhn = svhn)
-        
+        mnist = ResampleDataset(mnist.data, lambda d, i: i_mnist[i], size=len(i_mnist))
+        svhn = ResampleDataset(svhn.data, lambda d, i: i_svhn[i], size=len(i_svhn))
+
+        data = dict(mnist=mnist, svhn=svhn)
+
         self.data_path = data_path
         super().__init__(data, labels)
-        
-    
+
     def _check_pairing_exists(self, data_path, split):
-        
-        if not os.path.exists(data_path + '/mnist_svhn_idx/' + split +'/mnist_idx.pt'):
+        if not os.path.exists(data_path + "/mnist_svhn_idx/" + split + "/mnist_idx.pt"):
             return False
-        if not os.path.exists(data_path + '/mnist_svhn_idx/' + split +'/svhn_idx.pt'):
+        if not os.path.exists(data_path + "/mnist_svhn_idx/" + split + "/svhn_idx.pt"):
             return False
         return True
-    
-    def rand_match_on_idx(self,l1, idx1, l2, idx2, max_d=10000, dm=10):
 
+    def rand_match_on_idx(self, l1, idx1, l2, idx2, max_d=10000, dm=10):
         _idx1, _idx2 = [], []
         for l in l1.unique():  # assuming both have same idxs
             l_idx1, l_idx2 = idx1[l1 == l], idx2[l2 == l]
@@ -82,23 +87,20 @@ class MnistSvhn(MultimodalBaseDataset):
                 _idx1.append(l_idx1[torch.randperm(n)])
                 _idx2.append(l_idx2[torch.randperm(n)])
         return torch.cat(_idx1), torch.cat(_idx2)
-    
-    def create_pairing(self, mnist : MNIST, svhn : SVHN, data_path : str, max_d = 10000, dm = 5):
-        
+
+    def create_pairing(
+        self, mnist: MNIST, svhn: SVHN, data_path: str, max_d=10000, dm=5
+    ):
         split = svhn.split
         # Refactor svhn labels to match mnist labels
         svhn.labels = torch.LongTensor(svhn.labels.squeeze().astype(int)) % 10
         mnist_l, mnist_li = mnist.targets.sort()
         svhn_l, svhn_li = svhn.labels.sort()
-        idx1, idx2 = self.rand_match_on_idx(mnist_l, mnist_li, svhn_l, svhn_li, max_d=max_d, dm=dm)
-        
-        path = Path(data_path + '/mnist_svhn_idx/' + split)
+        idx1, idx2 = self.rand_match_on_idx(
+            mnist_l, mnist_li, svhn_l, svhn_li, max_d=max_d, dm=dm
+        )
+
+        path = Path(data_path + "/mnist_svhn_idx/" + split)
         path.mkdir(parents=True, exist_ok=True)
-        torch.save(idx1, str(path) + '/mnist_idx.pt' )
-        torch.save(idx2, str(path) + '/svhn_idx.pt')
-        
-
-
-
-
-
+        torch.save(idx1, str(path) + "/mnist_idx.pt")
+        torch.save(idx2, str(path) + "/svhn_idx.pt")

--- a/src/multivae/data/datasets/utils.py
+++ b/src/multivae/data/datasets/utils.py
@@ -33,7 +33,6 @@ class ResampleDataset(Dataset):
         idx = self.sampler(self.dataset, idx)
 
         if idx < 0 or idx >= len(self.dataset):
-            raise IndexError('out of range')
+            raise IndexError("out of range")
 
         return self.dataset[idx]
-

--- a/src/multivae/models/__init__.py
+++ b/src/multivae/models/__init__.py
@@ -1,12 +1,15 @@
 """Implementations of MultiVAE models
 """
 
-from .base import BaseMultiVAEConfig, BaseMultiVAE
-from .jmvae import JMVAEConfig, JMVAE
+from .auto_model import AutoConfig, AutoModel
+from .base import BaseMultiVAE, BaseMultiVAEConfig
+from .jmvae import JMVAE, JMVAEConfig
 
 __all__ = [
     "BaseMultiVAEConfig",
     "BaseMultiVAE",
     "JMVAEConfig",
-    "JMVAE"
+    "JMVAE",
+    "AutoConfig",
+    "AutoModel",
 ]

--- a/src/multivae/models/auto_model/__init__.py
+++ b/src/multivae/models/auto_model/__init__.py
@@ -1,0 +1,8 @@
+"""
+Builds config and models automatically
+"""
+
+from .auto_config import AutoConfig
+from .auto_model import AutoModel
+
+__all__ = ["AutoConfig", "AutoModel"]

--- a/src/multivae/models/auto_model/auto_config.py
+++ b/src/multivae/models/auto_model/auto_config.py
@@ -1,0 +1,38 @@
+from pydantic.dataclasses import dataclass
+from pythae.config import BaseConfig
+
+
+@dataclass
+class AutoConfig(BaseConfig):
+    @classmethod
+    def from_json_file(cls, json_path):
+        """Creates a :class:`~multivae.config.BaseMultiVAEConfig` instance from a JSON config file. It
+        builds automatically the correct config for any `pythae.models`.
+
+        Args:
+            json_path (str): The path to the json file containing all the parameters
+
+        Returns:
+            :class:`BaseMultiVAEConfig`: The created instance
+        """
+
+        config_dict = cls._dict_from_json(json_path)
+        config_name = config_dict.pop("name")
+
+        if config_name == "BaseMultiVAEConfig":
+            from ..base import BaseMultiVAEConfig
+
+            model_config = BaseMultiVAEConfig.from_json_file(json_path)
+
+        elif config_name == "JMVAEConfig":
+            from ..jmvae import JMVAEConfig
+
+            model_config = JMVAEConfig.from_json_file(json_path)
+
+        else:
+            raise NameError(
+                "Cannot reload automatically the model configuration... "
+                f"The model name in the `model_config.json may be corrupted. Got `{config_name}`"
+            )
+
+        return model_config

--- a/src/multivae/models/auto_model/auto_model.py
+++ b/src/multivae/models/auto_model/auto_model.py
@@ -1,0 +1,51 @@
+import json
+import logging
+import os
+
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+console = logging.StreamHandler()
+logger.addHandler(console)
+logger.setLevel(logging.INFO)
+
+
+class AutoModel(nn.Module):
+    "Utils class allowing to reload any :class:`multivae.models` automatically"
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @classmethod
+    def load_from_folder(cls, dir_path: str):
+        """Class method to be used to load the model from a specific folder
+
+        Args:
+            dir_path (str): The path where the model should have been be saved.
+
+        .. note::
+            This function requires the folder to contain:
+
+            - | a ``model_config.json`` and a ``model.pt`` if no custom architectures were provided
+
+            **or**
+
+            - | a ``model_config.json``, a ``model.pt`` and a ``encoders.pkl`` (resp.
+                ``decoders.pkl``) if a custom encoders (resp. decoders) were provided
+        """
+
+        with open(os.path.join(dir_path, "model_config.json")) as f:
+            model_name = json.load(f)["name"]
+
+        if model_name == "JMVAEConfig":
+            from ..jmvae import JMVAE
+
+            model = JMVAE.load_from_folder(dir_path=dir_path)
+
+        else:
+            raise NameError(
+                "Cannot reload automatically the model... "
+                f"The model name in the `model_config.json may be corrupted. Got {model_name}"
+            )
+
+        return model

--- a/src/multivae/models/base/__init__.py
+++ b/src/multivae/models/base/__init__.py
@@ -2,9 +2,7 @@
 **Abstract class**
 """
 
-from .base_model import BaseMultiVAE
 from .base_config import BaseMultiVAEConfig
+from .base_model import BaseMultiVAE
 
-
-__all__ = ["BaseMultiVAEConfig", 
-           "BaseMultiVAE"]
+__all__ = ["BaseMultiVAEConfig", "BaseMultiVAE"]

--- a/src/multivae/models/base/base_config.py
+++ b/src/multivae/models/base/base_config.py
@@ -16,3 +16,5 @@ class BaseMultiVAEConfig(BaseConfig):
     n_modalities: Union[int, None] = None
     latent_dim: int = 10
     input_dims: dict = None
+    uses_default_encoders: bool = True
+    uses_default_decoders: bool = True

--- a/src/multivae/models/base/base_model.py
+++ b/src/multivae/models/base/base_model.py
@@ -1,18 +1,18 @@
-
+import inspect
 import os
 from copy import deepcopy
 
 import cloudpickle
-import inspect
 import torch
 import torch.nn as nn
-from pythae.models.base.base_utils import ModelOutput
+from pythae.models.base.base_utils import CPU_Unpickler, ModelOutput
 from pythae.models.nn.base_architectures import BaseDecoder, BaseEncoder
 
 from ...data.datasets.base import MultimodalBaseDataset
+from ..auto_model import AutoConfig
+from ..nn.default_architectures import BaseDictDecoders, BaseDictEncoders
 from .base_config import BaseMultiVAEConfig
 
-from ..nn.default_architectures import BaseDictEncoders, BaseDictDecoders
 
 class BaseMultiVAE(nn.Module):
     """Base class for Multimodal VAE models.
@@ -21,11 +21,11 @@ class BaseMultiVAE(nn.Module):
         model_config (BaseMultiVAEConfig): An instance of BaseMultiVAEConfig in which any model's parameters is
             made available.
 
-        encoders (Dict[BaseEncoder]): A dictionary containing the modalities names and the encoders for each 
-            modality. Each encoder is an instance of Pythae's BaseEncoder. 
+        encoders (Dict[BaseEncoder]): A dictionary containing the modalities names and the encoders for each
+            modality. Each encoder is an instance of Pythae's BaseEncoder.
 
-        decoder (Dict[BaseDecoder]): A dictionary containing the modalities names and the decoders for each 
-            modality. Each decoder is an instance of Pythae's BaseDecoder. 
+        decoder (Dict[BaseDecoder]): A dictionary containing the modalities names and the decoders for each
+            modality. Each decoder is an instance of Pythae's BaseDecoder.
 
 
     """
@@ -34,18 +34,17 @@ class BaseMultiVAE(nn.Module):
         self,
         model_config: BaseMultiVAEConfig,
         encoders: dict = None,
-        decoders: dict = None
+        decoders: dict = None,
     ):
-
         nn.Module.__init__(self)
 
         self.model_name = "BaseMultiVAE"
         self.model_config = model_config
         self.n_modalities = model_config.n_modalities
         self.input_dims = model_config.input_dims
-        self.model_config.ses_default_encoders = False
-        self.model_config.ses_default_decoders = False
-        
+        self.model_config.uses_default_encoders = False
+        self.model_config.uses_default_decoders = False
+
         if encoders is None:
             if self.input_dims is None:
                 raise AttributeError(
@@ -54,7 +53,7 @@ class BaseMultiVAE(nn.Module):
             else:
                 encoders = BaseDictEncoders(self.input_dims, model_config.latent_dim)
                 self.model_config.uses_default_encoders = True
-        
+
         if decoders is None:
             if self.input_dims is None:
                 raise AttributeError(
@@ -63,32 +62,30 @@ class BaseMultiVAE(nn.Module):
             else:
                 decoders = BaseDictDecoders(self.input_dims, model_config.latent_dim)
                 self.model_config.uses_default_decoders = True
-        
+
         self.sanity_check(encoders, decoders)
-        
+
         self.latent_dim = model_config.latent_dim
         self.model_config = model_config
 
-        
         self.set_decoders(decoders)
         self.set_encoders(encoders)
 
         self.device = None
-        
+
     def sanity_check(self, encoders, decoders):
-        
         if self.n_modalities != len(encoders.keys()):
             raise AttributeError(
                 f"The provided number of encoders {len(encoders.keys())} doesn't"
                 f"match the number of modalities ({self.n_modalities} in model config "
             )
-        
+
         if self.n_modalities != len(decoders.keys()):
             raise AttributeError(
                 f"The provided number of decoders {len(decoders.keys())} doesn't"
                 f"match the number of modalities ({self.n_modalities} in model config "
             )
-            
+
         if encoders.keys() != decoders.keys():
             raise AttributeError(
                 "The names of the modalities in the encoders dict doesn't match the names of the modalities"
@@ -120,8 +117,6 @@ class BaseMultiVAE(nn.Module):
         By default, it does nothing.
         """
         pass
-
-
 
     def set_encoders(self, encoders: dict) -> None:
         """Set the encoders of the model"""
@@ -189,3 +184,122 @@ class BaseMultiVAE(nn.Module):
                 cloudpickle.dump(self.decoder, fp)
 
         torch.save(model_dict, os.path.join(dir_path, "model.pt"))
+
+    @classmethod
+    def _load_model_config_from_folder(cls, dir_path):
+        file_list = os.listdir(dir_path)
+
+        if "model_config.json" not in file_list:
+            raise FileNotFoundError(
+                f"Missing model config file ('model_config.json') in"
+                f"{dir_path}... Cannot perform model building."
+            )
+
+        path_to_model_config = os.path.join(dir_path, "model_config.json")
+        model_config = AutoConfig.from_json_file(path_to_model_config)
+
+        return model_config
+
+    @classmethod
+    def _load_model_weights_from_folder(cls, dir_path):
+        file_list = os.listdir(dir_path)
+
+        if "model.pt" not in file_list:
+            raise FileNotFoundError(
+                f"Missing model weights file ('model.pt') file in"
+                f"{dir_path}... Cannot perform model building."
+            )
+
+        path_to_model_weights = os.path.join(dir_path, "model.pt")
+
+        try:
+            model_weights = torch.load(path_to_model_weights, map_location="cpu")
+
+        except RuntimeError:
+            RuntimeError(
+                "Enable to load model weights. Ensure they are saves in a '.pt' format."
+            )
+
+        if "model_state_dict" not in model_weights.keys():
+            raise KeyError(
+                "Model state dict is not available in 'model.pt' file. Got keys:"
+                f"{model_weights.keys()}"
+            )
+
+        model_weights = model_weights["model_state_dict"]
+
+        return model_weights
+
+    @classmethod
+    def _load_custom_encoders_from_folder(cls, dir_path):
+        file_list = os.listdir(dir_path)
+        cls._check_python_version_from_folder(dir_path=dir_path)
+
+        if "encoders.pkl" not in file_list:
+            raise FileNotFoundError(
+                f"Missing encoder pkl file ('encoder.pkl') in"
+                f"{dir_path}... This file is needed to rebuild custom encoders."
+                " Cannot perform model building."
+            )
+
+        else:
+            with open(os.path.join(dir_path, "encoder.pkl"), "rb") as fp:
+                encoder = CPU_Unpickler(fp).load()
+
+        return encoder
+
+    @classmethod
+    def _load_custom_decoders_from_folder(cls, dir_path):
+        file_list = os.listdir(dir_path)
+        cls._check_python_version_from_folder(dir_path=dir_path)
+
+        if "decoders.pkl" not in file_list:
+            raise FileNotFoundError(
+                f"Missing decoder pkl file ('decoder.pkl') in"
+                f"{dir_path}... This file is needed to rebuild custom decoders."
+                " Cannot perform model building."
+            )
+
+        else:
+            with open(os.path.join(dir_path, "decoder.pkl"), "rb") as fp:
+                decoder = CPU_Unpickler(fp).load()
+
+        return decoder
+
+    @classmethod
+    def load_from_folder(cls, dir_path: str):
+        """Class method to be used to load the model from a specific folder
+
+        Args:
+            dir_path (str): The path where the model should have been be saved.
+
+        .. note::
+            This function requires the folder to contain:
+
+            - | a ``model_config.json`` and a ``model.pt`` if no custom architectures were provided
+
+            **or**
+
+            - | a ``model_config.json``, a ``model.pt`` and a ``encoders.pkl`` (resp.
+                ``decoders.pkl``) if a custom encoders (resp. decoders) were provided
+        """
+
+        model_config = cls._load_model_config_from_folder(dir_path)
+        model_weights = cls._load_model_weights_from_folder(dir_path)
+
+        if not model_config.uses_default_encoders:
+            encoders = cls._load_custom_encoders_from_folder(dir_path)
+
+        else:
+            encoders = None
+
+        if not model_config.uses_default_decoders:
+            decoders = cls._load_custom_decoders_from_folder(dir_path)
+
+        else:
+            decoders = None
+
+        model = cls(model_config, encoders=encoders, decoders=decoders)
+        model.load_state_dict(model_weights)
+
+        return model

--- a/src/multivae/models/jmvae/__init__.py
+++ b/src/multivae/models/jmvae/__init__.py
@@ -1,5 +1,4 @@
 from .jmvae_config import JMVAEConfig
 from .jmvae_model import JMVAE
 
-__all__ = ['JMVAEConfig',
-           'JMVAE']
+__all__ = ["JMVAEConfig", "JMVAE"]

--- a/src/multivae/models/jmvae/jmvae_config.py
+++ b/src/multivae/models/jmvae/jmvae_config.py
@@ -1,19 +1,21 @@
 from typing import Tuple, Union
 
 from pydantic.dataclasses import dataclass
+
 from ..joint_models import BaseJointModelConfig
+
 
 @dataclass
 class JMVAEConfig(BaseJointModelConfig):
     """
-    This is the base config for the JMVAE model. 
-    
+    This is the base config for the JMVAE model.
+
     Args :
-        alpha (float):  the parameter that controls the tradeoff between the ELBO and the 
+        alpha (float):  the parameter that controls the tradeoff between the ELBO and the
             regularization term. Default to 0.1.
         warmup (int): The number of warmup epochs during training.
 
     """
-    
+
     alpha: float = 0.1
     warmup: int = 1

--- a/src/multivae/models/jmvae/jmvae_model.py
+++ b/src/multivae/models/jmvae/jmvae_model.py
@@ -1,76 +1,94 @@
+from typing import Tuple, Union
+
+import torch
+import torch.distributions as dist
+from pythae.models.base.base_utils import ModelOutput
+from pythae.models.nn.base_architectures import BaseDecoder, BaseEncoder
+
+from ...data.datasets.base import MultimodalBaseDataset
 from ..joint_models import BaseJointModel
 from .jmvae_config import JMVAEConfig
-from typing import Tuple, Union
-from pythae.models.nn.base_architectures import BaseDecoder, BaseEncoder
-from ...data.datasets.base import MultimodalBaseDataset
-from pythae.models.base.base_utils import ModelOutput
-import torch.distributions as dist
-import torch
+
 
 class JMVAE(BaseJointModel):
-    
-    """The JMVAE model from the paper 'Joint Multimodal Learning with Deep Generative Models' 
+
+    """The JMVAE model from the paper 'Joint Multimodal Learning with Deep Generative Models'
     (Suzuki et al, 2016), http://arxiv.org/abs/1611.01891."""
-    
-    def __init__(self, model_config: JMVAEConfig, encoders: dict=None, decoders: dict=None, joint_encoder: Union[BaseEncoder, None] = None, **kwargs):
+
+    def __init__(
+        self,
+        model_config: JMVAEConfig,
+        encoders: dict = None,
+        decoders: dict = None,
+        joint_encoder: Union[BaseEncoder, None] = None,
+        **kwargs,
+    ):
         super().__init__(model_config, encoders, decoders, joint_encoder, **kwargs)
 
-        self.model_name = 'JMVAE'
+        self.model_name = "JMVAE"
 
         self.alpha = model_config.alpha
         self.warmup = model_config.warmup
-
 
     def forward(self, inputs: MultimodalBaseDataset, **kwargs) -> ModelOutput:
         """Performs a forward pass of the JMVAE model on inputs.
 
         Args:
             inputs (MultimodalBaseDataset)
-            warmup (int) : number of warmup epochs to do. The weigth of the regularization augments linearly to reach 1 at the end of
-                the warmup. The enforces the optimization of the reconstruction term only at first. 
-            epoch (int) : the epoch number during which forward is called.    
+            warmup (int) : number of warmup epochs to do. The weigth of the regularization augments
+                linearly to reach 1 at the end of the warmup. The enforces the optimization of
+                the reconstruction term only at first.
+            epoch (int) : the epoch number during which forward is called.
 
         Returns:
             ModelOutput
         """
 
-        epoch = kwargs.pop('epoch', 1)
+        epoch = kwargs.pop("epoch", 1)
 
         # Compute the reconstruction term
         joint_output = self.joint_encoder(inputs.data)
         mu, log_var = joint_output.embedding, joint_output.log_covariance
 
-        sigma = torch.exp(0.5*log_var)
+        sigma = torch.exp(0.5 * log_var)
         qz_xy = dist.Normal(mu, sigma)
         z_joint = qz_xy.rsample()
-        
+
         recon_loss = 0
-        
+
         # Decode in each modality
         for mod in self.decoders:
             x_mod = inputs.data[mod]
             recon_mod = self.decoders[mod](z_joint).reconstruction
-            recon_loss += -0.5*torch.sum((x_mod - recon_mod)**2)
-            
-        
+            recon_loss += -0.5 * torch.sum((x_mod - recon_mod) ** 2)
+
         # Compute the KLD to the prior
-        KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp())        
-        
+        KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp())
+
         # Compute the KL between unimodal and joint encoders
         LJM = 0
         for mod in self.encoders:
             output = self.encoders[mod](inputs.data[mod])
             uni_mu, uni_log_var = output.embedding, output.log_covariance
-            LJM += 1/2*(uni_log_var-log_var +  (torch.exp(log_var) + (mu - uni_mu)**2)/torch.exp(uni_log_var) - 1)
-        
-        LJM = LJM.sum()*self.alpha
-        
+            LJM += (
+                1
+                / 2
+                * (
+                    uni_log_var
+                    - log_var
+                    + (torch.exp(log_var) + (mu - uni_mu) ** 2) / torch.exp(uni_log_var)
+                    - 1
+                )
+            )
+
+        LJM = LJM.sum() * self.alpha
+
         # Compute the total loss to minimize
-        
+
         reg_loss = KLD + LJM
         beta = min(1, epoch / self.warmup)
-        loss = recon_loss - beta*reg_loss
-        
+        loss = recon_loss - beta * reg_loss
+
         output = ModelOutput(loss=loss)
-        
+
         return output

--- a/src/multivae/models/joint_models/__init__.py
+++ b/src/multivae/models/joint_models/__init__.py
@@ -1,5 +1,4 @@
 from .joint_model import BaseJointModel
 from .joint_model_config import BaseJointModelConfig
 
-__all__ = [ "BaseJointModel",
-           "BaseJointModelConfig"]
+__all__ = ["BaseJointModel", "BaseJointModelConfig"]

--- a/src/multivae/models/joint_models/joint_model.py
+++ b/src/multivae/models/joint_models/joint_model.py
@@ -1,51 +1,55 @@
-from ..base import BaseMultiVAE
-from .joint_model_config import BaseJointModelConfig
-from pythae.models.nn.base_architectures import BaseEncoder, BaseDecoder
 from typing import Tuple, Union
+
+from pythae.models.nn.base_architectures import BaseDecoder, BaseEncoder
+
+from ..base import BaseMultiVAE
 from ..nn.default_architectures import MultipleHeadJointEncoder
-
-
-
+from .joint_model_config import BaseJointModelConfig
 
 
 class BaseJointModel(BaseMultiVAE):
     """
     Base Class for models using a joint encoder.
-    
+
     Args:
-        
+
         model_config (BaseJointModelConfig): The configuration of the model.
-        
-        encoders (Dict[BaseEncoder]): A dictionary containing the modalities names and the encoders for each 
+
+        encoders (Dict[BaseEncoder]): A dictionary containing the modalities names and the encoders for each
             modality. Each encoder is an instance of Pythae's BaseEncoder class.
 
-        decoder (Dict[BaseDecoder]): A dictionary containing the modalities names and the decoders for each 
-            modality. Each decoder is an instance of Pythae's BaseDecoder class. 
-            
-        joint_encoder (BaseEncoder) : An instance of BaseEncoder that takes all the modalities as an input. 
-            If none is provided, one is created from the unimodal encoders. Default : None. 
+        decoder (Dict[BaseDecoder]): A dictionary containing the modalities names and the decoders for each
+            modality. Each decoder is an instance of Pythae's BaseDecoder class.
+
+        joint_encoder (BaseEncoder) : An instance of BaseEncoder that takes all the modalities as an input.
+            If none is provided, one is created from the unimodal encoders. Default : None.
     """
 
-    def __init__(self, model_config: BaseJointModelConfig, encoders: dict=None, decoders: dict=None, joint_encoder : Union[BaseEncoder, None]=None, **kwargs):
+    def __init__(
+        self,
+        model_config: BaseJointModelConfig,
+        encoders: dict = None,
+        decoders: dict = None,
+        joint_encoder: Union[BaseEncoder, None] = None,
+        **kwargs,
+    ):
         super().__init__(model_config, encoders, decoders)
-        
+
         if joint_encoder is None:
             # Create a MultiHead Joint Encoder MLP
-            joint_encoder = MultipleHeadJointEncoder(self.encoders,model_config)
+            joint_encoder = MultipleHeadJointEncoder(self.encoders, model_config)
             model_config.use_default_joint = True
-        
+
         self.set_joint_encoder(joint_encoder)
-        
+
     def set_joint_encoder(self, joint_encoder):
         "Checks that the provided joint encoder is an instance of BaseEncoder."
-        
+
         if not issubclass(type(joint_encoder), BaseEncoder):
-                raise AttributeError(
-                    (
-                        f"The joint encoder must inherit from BaseEncoder class from "
-                        "pythae.models.base_architectures.BaseEncoder. Refer to documentation."
-                    )
+            raise AttributeError(
+                (
+                    f"The joint encoder must inherit from BaseEncoder class from "
+                    "pythae.models.base_architectures.BaseEncoder. Refer to documentation."
                 )
+            )
         self.joint_encoder = joint_encoder
-        
-        

--- a/src/multivae/models/joint_models/joint_model_config.py
+++ b/src/multivae/models/joint_models/joint_model_config.py
@@ -1,19 +1,19 @@
 from typing import Tuple, Union
 
 from pydantic.dataclasses import dataclass
+
 from ..base.base_config import BaseMultiVAEConfig
+
 
 @dataclass
 class BaseJointModelConfig(BaseMultiVAEConfig):
     """
     This is the base config for joint models.
-    
+
     Args :
         use_default_joint (bool) :  A boolean encoding if the joint encoder used is the default one.
 
 
     """
-    
-    use_default_joint : bool = False
 
-    
+    use_default_joint: bool = False

--- a/src/multivae/models/nn/default_architectures.py
+++ b/src/multivae/models/nn/default_architectures.py
@@ -1,25 +1,29 @@
-from pythae.models.nn.base_architectures import BaseEncoder
-from pythae.models.base import BaseAEConfig
-from pythae.models.nn.default_architectures import Encoder_VAE_MLP, Decoder_AE_MLP
 from copy import deepcopy
-from torch import nn
+
 import numpy as np
 import torch
+from pythae.models.base import BaseAEConfig
 from pythae.models.base.base_utils import ModelOutput
+from pythae.models.nn.base_architectures import BaseEncoder
+from pythae.models.nn.default_architectures import Decoder_AE_MLP, Encoder_VAE_MLP
+from torch import nn
 
-def BaseDictEncoders(input_dims : dict, latent_dim:int):
+
+def BaseDictEncoders(input_dims: dict, latent_dim: int):
     encoders = nn.ModuleDict()
     for mod in input_dims:
-        config = BaseAEConfig(input_dim = input_dims[mod], latent_dim=latent_dim)
+        config = BaseAEConfig(input_dim=input_dims[mod], latent_dim=latent_dim)
         encoders[mod] = Encoder_VAE_MLP(config)
     return encoders
 
-def BaseDictDecoders(input_dims : dict, latent_dim :int):
+
+def BaseDictDecoders(input_dims: dict, latent_dim: int):
     decoders = nn.ModuleDict()
     for mod in input_dims:
-        config = BaseAEConfig(input_dim = input_dims[mod], latent_dim=latent_dim)
+        config = BaseAEConfig(input_dim=input_dims[mod], latent_dim=latent_dim)
         decoders[mod] = Decoder_AE_MLP(config)
     return decoders
+
 
 class MultipleHeadJointEncoder(BaseEncoder):
     """
@@ -31,54 +35,58 @@ class MultipleHeadJointEncoder(BaseEncoder):
             args (dict): config dictionary. Contains the latent dim.
             hidden_dim (int) : Default to 512.
             n_hidden_layers (int) : Default to 2.
-        """
-    def __init__(self, dict_encoders :nn.ModuleDict, args:dict, hidden_dim=512, n_hidden_layers=2, **kwargs):
+    """
 
+    def __init__(
+        self,
+        dict_encoders: nn.ModuleDict,
+        args: dict,
+        hidden_dim=512,
+        n_hidden_layers=2,
+        **kwargs,
+    ):
         super().__init__()
-        
-        # Duplicate all the unimodal encoders with identical instances. 
+
+        # Duplicate all the unimodal encoders with identical instances.
         self.encoders = nn.ModuleDict()
         self.joint_input_dim = 0
         for modality in dict_encoders:
             self.encoders[modality] = deepcopy(dict_encoders[modality])
             self.joint_input_dim += self.encoders[modality].latent_dim
-        
-        modules = [nn.Sequential(nn.Linear(self.joint_input_dim, hidden_dim), nn.ReLU(True))]
-        for i in range(n_hidden_layers-1):
-            modules.extend([nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.ReLU(True))])
+
+        modules = [
+            nn.Sequential(nn.Linear(self.joint_input_dim, hidden_dim), nn.ReLU(True))
+        ]
+        for i in range(n_hidden_layers - 1):
+            modules.extend(
+                [nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.ReLU(True))]
+            )
 
         self.enc = nn.Sequential(*modules)
         self.fc1 = nn.Linear(hidden_dim, args.latent_dim)
         self.fc2 = nn.Linear(hidden_dim, args.latent_dim)
-        
+
         self.latent_dim = args.latent_dim
-        
-    
-    def forward(self, x : dict):
-        """ 
+
+    def forward(self, x: dict):
+        """
         Implements the encoding of the data contained in x.
 
         Args:
             x (dict): Contains a tensor for each modality (key).
         """
-        
-        assert(np.all(x.keys()==self.encoders.keys()))
-        
+
+        assert np.all(x.keys() == self.encoders.keys())
+
         modalities_outputs = []
         for mod in self.encoders:
-            modalities_outputs.append(self.encoders[mod](x[mod])['embedding'])
+            modalities_outputs.append(self.encoders[mod](x[mod])["embedding"])
 
         # Stack the modalities outputs
-        concatened_outputs = torch.cat(modalities_outputs,dim=1)
-        h=self.enc(concatened_outputs)
+        concatened_outputs = torch.cat(modalities_outputs, dim=1)
+        h = self.enc(concatened_outputs)
         embedding = self.fc1(h)
         log_covariance = self.fc2(h)
         output = ModelOutput(embedding=embedding, log_covariance=log_covariance)
-        
+
         return output
-        
-            
-        
-        
-
-

--- a/src/multivae/trainers/__init__.py
+++ b/src/multivae/trainers/__init__.py
@@ -1,7 +1,4 @@
 from .base_trainer import BaseTrainer
 from .base_trainer_config import BaseTrainerConfig
 
-__all__ = [
-    "BaseTrainer",
-    "BaseTrainerConfig"
-]
+__all__ = ["BaseTrainer", "BaseTrainerConfig"]

--- a/src/multivae/trainers/base_trainer.py
+++ b/src/multivae/trainers/base_trainer.py
@@ -8,22 +8,21 @@ import torch
 import torch.distributed as dist
 import torch.optim as optim
 import torch.optim.lr_scheduler as lr_scheduler
+from pythae.data.datasets import DatasetOutput
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
-from pythae.data.datasets import DatasetOutput
-
 from ..data import MultimodalBaseDataset
 from ..models import BaseMultiVAE
-from .utils import set_seed
+from .base_trainer_config import BaseTrainerConfig
 from .callbacks import (
     CallbackHandler,
     MetricConsolePrinterCallback,
     ProgressBarCallback,
     TrainingCallback,
 )
-from .base_trainer_config import BaseTrainerConfig
+from .utils import set_seed
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +60,6 @@ class BaseTrainer:
         training_config: Optional[BaseTrainerConfig] = None,
         callbacks: List[TrainingCallback] = None,
     ):
-
         if training_config is None:
             training_config = BaseTrainerConfig()
 
@@ -326,7 +324,6 @@ class BaseTrainer:
         return optim
 
     def _set_inputs_to_device(self, inputs: Dict[str, Any]):
-
         inputs_on_device = inputs
 
         if self.device == "cuda":
@@ -342,7 +339,7 @@ class BaseTrainer:
                         if torch.is_tensor(inputs[key][subkey]):
                             cuda_inputs[key][subkey] = inputs[key][subkey].cuda()
                         else:
-                            cuda_inputs[key][subkey] = inputs[key][subkey]            
+                            cuda_inputs[key][subkey] = inputs[key][subkey]
 
                 else:
                     cuda_inputs[key] = inputs[key]
@@ -351,7 +348,6 @@ class BaseTrainer:
         return DatasetOutput(**inputs_on_device)
 
     def _optimizers_step(self, model_output=None):
-
         loss = model_output.loss
 
         self.optimizer.zero_grad()
@@ -429,7 +425,6 @@ class BaseTrainer:
         best_eval_loss = 1e10
 
         for epoch in range(1, self.training_config.num_epochs + 1):
-
             self.callback_handler.on_epoch_begin(
                 training_config=self.training_config,
                 epoch=epoch,
@@ -541,12 +536,10 @@ class BaseTrainer:
         epoch_loss = 0
 
         for inputs in self.eval_loader:
-
             inputs = self._set_inputs_to_device(inputs)
 
             try:
                 with torch.no_grad():
-
                     model_output = self.model(
                         inputs,
                         epoch=epoch,
@@ -597,7 +590,6 @@ class BaseTrainer:
         epoch_loss = 0
 
         for inputs in self.train_loader:
-
             inputs = self._set_inputs_to_device(inputs)
 
             model_output = self.model(
@@ -689,7 +681,6 @@ class BaseTrainer:
         self.training_config.save_json(checkpoint_dir, "training_config")
 
     def predict(self, model: BaseMultiVAE):
-
         model.eval()
 
         inputs = next(iter(self.eval_loader))

--- a/src/multivae/trainers/base_trainer_config.py
+++ b/src/multivae/trainers/base_trainer_config.py
@@ -4,7 +4,6 @@ from typing import Union
 
 import torch.nn as nn
 from pydantic.dataclasses import dataclass
-
 from pythae.config import BaseConfig
 
 

--- a/src/multivae/trainers/callbacks.py
+++ b/src/multivae/trainers/callbacks.py
@@ -203,7 +203,6 @@ class MetricConsolePrinterCallback(TrainingCallback):
         self.logger.setLevel(logging.INFO)
 
     def on_log(self, training_config: BaseTrainerConfig, logs, **kwargs):
-
         logger = kwargs.pop("logger", self.logger)
         rank = kwargs.pop("rank", -1)
 
@@ -376,7 +375,6 @@ class WandbCallback(TrainingCallback):  # pragma: no cover
             and generations is not None
         ):
             for i in range(len(true_data)):
-
                 data_to_log.append(
                     [
                         f"img_{i}",

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -1,58 +1,61 @@
 import os
+
 import numpy as np
 import pytest
+from pythae.models.base import BaseAEConfig
+from pythae.models.nn.benchmarks.mnist.convnets import (
+    Decoder_Conv_AE_MNIST,
+    Encoder_Conv_AE_MNIST,
+)
+from pythae.models.nn.default_architectures import (
+    Decoder_AE_MLP,
+    Encoder_AE_MLP,
+    Encoder_VAE_MLP,
+)
 from torch import nn
 
 from multivae.models.base import BaseMultiVAE, BaseMultiVAEConfig
-from pythae.models.nn.default_architectures import Encoder_AE_MLP, Decoder_AE_MLP, Encoder_VAE_MLP  
-from pythae.models.nn.benchmarks.mnist.convnets import Encoder_Conv_AE_MNIST, Decoder_Conv_AE_MNIST
-from pythae.models.base import BaseAEConfig
+
 
 class Test_BaseMultiVAE:
-    
     @pytest.fixture
     def input_model1(self):
         model_config = BaseMultiVAEConfig(n_modalities=2, latent_dim=10)
-        config = BaseAEConfig(input_dim=(10,2), latent_dim=10)
-        encoders = dict(
-            mod1 = Encoder_AE_MLP(config),
-            mod2 = Encoder_Conv_AE_MNIST(config)
-        )
-        decoders = dict(
-            mod1 = Decoder_AE_MLP(config),
-            mod2 = Decoder_Conv_AE_MNIST(config)
-        )
-        return dict(model_config=model_config, encoders=encoders,decoders=decoders)
-    
+        config = BaseAEConfig(input_dim=(10, 2), latent_dim=10)
+        encoders = dict(mod1=Encoder_AE_MLP(config), mod2=Encoder_Conv_AE_MNIST(config))
+        decoders = dict(mod1=Decoder_AE_MLP(config), mod2=Decoder_Conv_AE_MNIST(config))
+        return dict(model_config=model_config, encoders=encoders, decoders=decoders)
+
     @pytest.fixture
     def input_model2(self):
-        model_config = BaseMultiVAEConfig(n_modalities=2, latent_dim=10, input_dims=dict(mod1 = (1,2), mod2 = (3,4,4)))
-        
-        return dict(model_config=model_config)
+        model_config = BaseMultiVAEConfig(
+            n_modalities=2, latent_dim=10, input_dims=dict(mod1=(1, 2), mod2=(3, 4, 4))
+        )
 
+        return dict(model_config=model_config)
 
     def test1(self, input_model1):
         model = BaseMultiVAE(**input_model1)
 
-        assert type(model.encoders)==nn.ModuleDict
-        assert isinstance(model.encoders['mod1'],Encoder_AE_MLP)
-        assert isinstance(model.encoders['mod2'],Encoder_Conv_AE_MNIST)
-        assert type(model.decoders)==nn.ModuleDict
-        assert isinstance(model.decoders['mod1'],Decoder_AE_MLP)
-        assert isinstance(model.decoders['mod2'],Decoder_Conv_AE_MNIST)
-        assert model.latent_dim == input_model1['model_config'].latent_dim
-        
+        assert type(model.encoders) == nn.ModuleDict
+        assert isinstance(model.encoders["mod1"], Encoder_AE_MLP)
+        assert isinstance(model.encoders["mod2"], Encoder_Conv_AE_MNIST)
+        assert type(model.decoders) == nn.ModuleDict
+        assert isinstance(model.decoders["mod1"], Decoder_AE_MLP)
+        assert isinstance(model.decoders["mod2"], Decoder_Conv_AE_MNIST)
+        assert model.latent_dim == input_model1["model_config"].latent_dim
+
     def test2(self, input_model2):
         model = BaseMultiVAE(**input_model2)
 
-        assert type(model.encoders)==nn.ModuleDict
-        assert isinstance(model.encoders['mod1'],Encoder_VAE_MLP)
-        assert model.encoders['mod1'].input_dim == (1,2)
-        assert isinstance(model.encoders['mod2'],Encoder_VAE_MLP)
-        assert model.encoders['mod2'].input_dim == (3,4,4)
-        assert type(model.decoders)==nn.ModuleDict
-        assert isinstance(model.decoders['mod1'],Decoder_AE_MLP)
-        assert model.decoders['mod1'].input_dim == (1,2)
-        assert isinstance(model.decoders['mod2'],Decoder_AE_MLP)
-        assert model.decoders['mod2'].input_dim == (3,4,4)
-        assert model.latent_dim == input_model2['model_config'].latent_dim
+        assert type(model.encoders) == nn.ModuleDict
+        assert isinstance(model.encoders["mod1"], Encoder_VAE_MLP)
+        assert model.encoders["mod1"].input_dim == (1, 2)
+        assert isinstance(model.encoders["mod2"], Encoder_VAE_MLP)
+        assert model.encoders["mod2"].input_dim == (3, 4, 4)
+        assert type(model.decoders) == nn.ModuleDict
+        assert isinstance(model.decoders["mod1"], Decoder_AE_MLP)
+        assert model.decoders["mod1"].input_dim == (1, 2)
+        assert isinstance(model.decoders["mod2"], Decoder_AE_MLP)
+        assert model.decoders["mod2"].input_dim == (3, 4, 4)
+        assert model.latent_dim == input_model2["model_config"].latent_dim

--- a/tests/test_joint_encoder.py
+++ b/tests/test_joint_encoder.py
@@ -1,39 +1,40 @@
 import os
+
 import numpy as np
 import pytest
-from torch import nn
 import torch
+from pythae.models.base import BaseAEConfig
+from pythae.models.nn.benchmarks.mnist.convnets import (
+    Decoder_Conv_AE_MNIST,
+    Encoder_Conv_AE_MNIST,
+)
+from pythae.models.nn.default_architectures import Decoder_AE_MLP, Encoder_AE_MLP
+from torch import nn
 
 from multivae.models.base import BaseMultiVAE, BaseMultiVAEConfig
 from multivae.models.nn.default_architectures import MultipleHeadJointEncoder
-from pythae.models.nn.default_architectures import Encoder_AE_MLP, Decoder_AE_MLP
-from pythae.models.nn.benchmarks.mnist.convnets import Encoder_Conv_AE_MNIST, Decoder_Conv_AE_MNIST
-from pythae.models.base import BaseAEConfig
+
 
 class Test_MultipleHeadJointEncoder:
-    
     @pytest.fixture
     def input_model(self):
         model_config = BaseMultiVAEConfig(n_modalities=2, latent_dim=10)
         config1 = BaseAEConfig(input_dim=(7,), latent_dim=10)
         config2 = BaseAEConfig(input_dim=(3,), latent_dim=10)
 
-        encoders = dict(
-            mod1 = Encoder_AE_MLP(config1),
-            mod2 = Encoder_AE_MLP(config2)
-        )
-        data = dict(mod1 = torch.ones((3,7)), mod2=torch.ones((3,3)))
-        return dict(dict_encoders = encoders,args = model_config, data=data)
+        encoders = dict(mod1=Encoder_AE_MLP(config1), mod2=Encoder_AE_MLP(config2))
+        data = dict(mod1=torch.ones((3, 7)), mod2=torch.ones((3, 3)))
+        return dict(dict_encoders=encoders, args=model_config, data=data)
 
     def test(self, input_model):
         model = MultipleHeadJointEncoder(**input_model)
-        
-        assert type(model.encoders)== nn.ModuleDict
-        assert isinstance(model.encoders['mod1'],Encoder_AE_MLP)
-        assert model.encoders['mod1'] != input_model['dict_encoders']['mod1']
-        assert model.latent_dim == input_model['args'].latent_dim
-        
+
+        assert type(model.encoders) == nn.ModuleDict
+        assert isinstance(model.encoders["mod1"], Encoder_AE_MLP)
+        assert model.encoders["mod1"] != input_model["dict_encoders"]["mod1"]
+        assert model.latent_dim == input_model["args"].latent_dim
+
         # forward pass
-        outputs = model(input_model['data'])
-        assert outputs.embedding.shape == (3,10)
-        assert outputs.log_covariance.shape == (3,10)
+        outputs = model(input_model["data"])
+        assert outputs.embedding.shape == (3, 10)
+        assert outputs.log_covariance.shape == (3, 10)

--- a/tests/test_joint_model.py
+++ b/tests/test_joint_model.py
@@ -1,72 +1,74 @@
 import os
+
 import numpy as np
 import pytest
-from torch import nn
 import torch
+from pythae.models.base import BaseAEConfig
+from pythae.models.nn.benchmarks.mnist.convnets import (
+    Decoder_Conv_AE_MNIST,
+    Encoder_Conv_AE_MNIST,
+)
+from pythae.models.nn.default_architectures import (
+    Decoder_AE_MLP,
+    Encoder_AE_MLP,
+    Encoder_VAE_MLP,
+)
+from torch import nn
 
 from multivae.models.base import BaseMultiVAE, BaseMultiVAEConfig
 from multivae.models.joint_models import BaseJointModel
 from multivae.models.nn.default_architectures import MultipleHeadJointEncoder
-from pythae.models.nn.default_architectures import Encoder_AE_MLP, Decoder_AE_MLP, Encoder_VAE_MLP
-from pythae.models.nn.benchmarks.mnist.convnets import Encoder_Conv_AE_MNIST, Decoder_Conv_AE_MNIST
-from pythae.models.base import BaseAEConfig
+
 
 class Test_JointModel:
-    
     @pytest.fixture
     def input_model(self):
         model_config = BaseMultiVAEConfig(n_modalities=2, latent_dim=10)
         config1 = BaseAEConfig(input_dim=(7,), latent_dim=10)
         config2 = BaseAEConfig(input_dim=(3,), latent_dim=10)
 
-        encoders = dict(
-            mod1 = Encoder_AE_MLP(config1),
-            mod2 = Encoder_AE_MLP(config2)
-        )
-        
-        decoders = dict(
-            mod1 = Decoder_AE_MLP(config1),
-            mod2 = Decoder_AE_MLP(config2)
-        )
-        
-        data = dict(mod1 = torch.ones((3,7)), mod2=torch.ones((3,3)))
-        return dict(encoders = encoders,model_config=model_config, decoders=decoders)
+        encoders = dict(mod1=Encoder_AE_MLP(config1), mod2=Encoder_AE_MLP(config2))
+
+        decoders = dict(mod1=Decoder_AE_MLP(config1), mod2=Decoder_AE_MLP(config2))
+
+        data = dict(mod1=torch.ones((3, 7)), mod2=torch.ones((3, 3)))
+        return dict(encoders=encoders, model_config=model_config, decoders=decoders)
 
     def test(self, input_model):
         model = BaseJointModel(**input_model)
-        
-        assert type(model.encoders)==nn.ModuleDict
-        assert isinstance(model.encoders['mod1'],Encoder_AE_MLP)
-        assert isinstance(model.encoders['mod2'],Encoder_AE_MLP)
-        assert type(model.decoders)==nn.ModuleDict
-        assert isinstance(model.decoders['mod1'],Decoder_AE_MLP)
-        assert isinstance(model.decoders['mod2'],Decoder_AE_MLP)
-        
-        assert isinstance(model.joint_encoder, MultipleHeadJointEncoder)
-        assert model.latent_dim == input_model['model_config'].latent_dim
 
+        assert type(model.encoders) == nn.ModuleDict
+        assert isinstance(model.encoders["mod1"], Encoder_AE_MLP)
+        assert isinstance(model.encoders["mod2"], Encoder_AE_MLP)
+        assert type(model.decoders) == nn.ModuleDict
+        assert isinstance(model.decoders["mod1"], Decoder_AE_MLP)
+        assert isinstance(model.decoders["mod2"], Decoder_AE_MLP)
+
+        assert isinstance(model.joint_encoder, MultipleHeadJointEncoder)
+        assert model.latent_dim == input_model["model_config"].latent_dim
 
     @pytest.fixture
     def input2(self):
-        
-        model_config = BaseMultiVAEConfig(n_modalities=2, latent_dim=10, input_dims=dict(mod1=(7,),mod2=(3,)))
+        model_config = BaseMultiVAEConfig(
+            n_modalities=2, latent_dim=10, input_dims=dict(mod1=(7,), mod2=(3,))
+        )
 
         return dict(model_config=model_config)
 
     def test2(self, input2):
         model = BaseJointModel(**input2)
-        
-        assert type(model.encoders)==nn.ModuleDict
-        assert isinstance(model.encoders['mod1'],Encoder_VAE_MLP)
-        assert isinstance(model.encoders['mod2'],Encoder_VAE_MLP)
-        assert model.encoders['mod1'].input_dim == (7,)
-        assert model.encoders['mod2'].input_dim == (3,)
-        assert model.encoders['mod1'].latent_dim == 10
-        assert model.encoders['mod2'].latent_dim == 10
 
-        assert type(model.decoders)==nn.ModuleDict
-        assert isinstance(model.decoders['mod1'],Decoder_AE_MLP)
-        assert isinstance(model.decoders['mod2'],Decoder_AE_MLP)
-        
+        assert type(model.encoders) == nn.ModuleDict
+        assert isinstance(model.encoders["mod1"], Encoder_VAE_MLP)
+        assert isinstance(model.encoders["mod2"], Encoder_VAE_MLP)
+        assert model.encoders["mod1"].input_dim == (7,)
+        assert model.encoders["mod2"].input_dim == (3,)
+        assert model.encoders["mod1"].latent_dim == 10
+        assert model.encoders["mod2"].latent_dim == 10
+
+        assert type(model.decoders) == nn.ModuleDict
+        assert isinstance(model.decoders["mod1"], Decoder_AE_MLP)
+        assert isinstance(model.decoders["mod2"], Decoder_AE_MLP)
+
         assert isinstance(model.joint_encoder, MultipleHeadJointEncoder)
-        assert model.latent_dim == input2['model_config'].latent_dim
+        assert model.latent_dim == input2["model_config"].latent_dim

--- a/tests/test_mnist_svhn_dataset.py
+++ b/tests/test_mnist_svhn_dataset.py
@@ -1,24 +1,24 @@
 import os
+
 import numpy as np
 import pytest
-
 from pythae.data.datasets import DatasetOutput
 
 from multivae.data.datasets.base import MultimodalBaseDataset
 from multivae.data.datasets.mnist_svhn import MnistSvhn
 
+
 class Test:
     @pytest.fixture
     def input_dataset_test(self):
-        
-        data_path = '../data'
-        split = 'test'
-        
+        data_path = "../data"
+        split = "test"
+
         return dict(data_path=data_path, split=split)
 
     def test_create_dataset(self, input_dataset_test):
         dataset = MnistSvhn(**input_dataset_test)
-        assert(isinstance(dataset, MultimodalBaseDataset))
+        assert isinstance(dataset, MultimodalBaseDataset)
         sample = dataset[0]
-        assert type(sample)==DatasetOutput
+        assert type(sample) == DatasetOutput
         assert len(dataset) == 50000

--- a/tests/test_multimodal_dataset.py
+++ b/tests/test_multimodal_dataset.py
@@ -1,7 +1,7 @@
 import os
+
 import numpy as np
 import pytest
-
 from pythae.data.datasets import DatasetOutput
 
 from multivae.data.datasets.base import MultimodalBaseDataset
@@ -11,17 +11,17 @@ class Test:
     @pytest.fixture
     def input_dataset_test(self):
         data = dict(
-            mod1 = np.array([[1,2],[4,5]]),
-            mod2 = np.array([[67,2,3],[1,2,3]]),
+            mod1=np.array([[1, 2], [4, 5]]),
+            mod2=np.array([[67, 2, 3], [1, 2, 3]]),
         )
-        labels = np.array([0,1])
+        labels = np.array([0, 1])
         return dict(data=data, labels=labels)
 
     def test_create_dataset(self, input_dataset_test):
         dataset = MultimodalBaseDataset(**input_dataset_test)
 
         sample = dataset[0]
-        assert type(sample)==DatasetOutput
-        assert np.all(sample['data']['mod1'] == np.array([1,2]))
-        assert np.all(sample['data']['mod2'] == np.array([67,2,3]))
-        assert sample['labels'] == 0
+        assert type(sample) == DatasetOutput
+        assert np.all(sample["data"]["mod1"] == np.array([1, 2]))
+        assert np.all(sample["data"]["mod2"] == np.array([67, 2, 3]))
+        assert sample["labels"] == 0

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -2,16 +2,19 @@ import os
 
 import pytest
 import torch
-
-from pythae.models.nn.default_architectures import Encoder_VAE_MLP, Decoder_AE_MLP
-from pythae.models.nn.benchmarks.mnist.convnets import Encoder_Conv_VAE_MNIST, Decoder_Conv_AE_MNIST
 from pythae.models.base import BaseAEConfig
+from pythae.models.nn.benchmarks.mnist.convnets import (
+    Decoder_Conv_AE_MNIST,
+    Encoder_Conv_VAE_MNIST,
+)
+from pythae.models.nn.default_architectures import Decoder_AE_MLP, Encoder_VAE_MLP
 
+from multivae.data import MultimodalBaseDataset
 from multivae.models import JMVAE, JMVAEConfig
 from multivae.trainers import BaseTrainer, BaseTrainerConfig
-from multivae.data import MultimodalBaseDataset
 
 PATH = os.path.dirname(os.path.abspath(__file__))
+
 
 @pytest.fixture
 def training_config(tmpdir):
@@ -19,34 +22,28 @@ def training_config(tmpdir):
     dir_path = os.path.join(tmpdir, "dummy_folder")
     return BaseTrainerConfig(output_dir=dir_path)
 
+
 @pytest.fixture
 def model_sample():
     model_config = JMVAEConfig(n_modalities=2, latent_dim=10)
     config = BaseAEConfig(input_dim=(1, 28, 28), latent_dim=10)
-    encoders = dict(
-        mod1 = Encoder_VAE_MLP(config),
-        mod2 = Encoder_Conv_VAE_MNIST(config)
-    )
-    decoders = dict(
-        mod1 = Decoder_AE_MLP(config),
-        mod2 = Decoder_Conv_AE_MNIST(config)
-    )
-    return JMVAE(
-        model_config=model_config, encoders=encoders, decoders=decoders
-    )
+    encoders = dict(mod1=Encoder_VAE_MLP(config), mod2=Encoder_Conv_VAE_MNIST(config))
+    decoders = dict(mod1=Decoder_AE_MLP(config), mod2=Decoder_Conv_AE_MNIST(config))
+    return JMVAE(model_config=model_config, encoders=encoders, decoders=decoders)
+
 
 @pytest.fixture
 def train_dataset():
     return MultimodalBaseDataset(
-        data = dict(
-            mod1 = torch.randn((2, 1, 28, 28)),
-            mod2 = torch.randn((2, 1, 28, 28)),
+        data=dict(
+            mod1=torch.randn((2, 1, 28, 28)),
+            mod2=torch.randn((2, 1, 28, 28)),
         ),
-        labels = torch.tensor([0,1])
+        labels=torch.tensor([0, 1]),
     )
 
-class Test_Set_Training_config:
 
+class Test_Set_Training_config:
     @pytest.fixture(
         params=[
             None,
@@ -112,7 +109,6 @@ class Test_Build_Optimizer:
         ]
     )
     def optimizer_config(self, request, training_configs_learning_rate):
-
         optimizer_config = request.param
 
         # set optim and params to training config
@@ -126,7 +122,6 @@ class Test_Build_Optimizer:
     def test_default_optimizer_building(
         self, model_sample, train_dataset, training_configs_learning_rate
     ):
-
         trainer = BaseTrainer(
             model=model_sample,
             train_dataset=train_dataset,
@@ -148,7 +143,6 @@ class Test_Build_Optimizer:
         training_configs_learning_rate,
         optimizer_config,
     ):
-
         trainer = BaseTrainer(
             model=model_sample,
             train_dataset=train_dataset,
@@ -199,7 +193,6 @@ class Test_Build_Scheduler:
         ]
     )
     def optimizer_config(self, request, training_configs_learning_rate):
-
         optimizer_config = request.param
 
         # set optim and params to training config
@@ -218,7 +211,6 @@ class Test_Build_Scheduler:
         ]
     )
     def scheduler_config(self, request, training_configs_learning_rate):
-
         scheduler_config = request.param
 
         # set scheduler and params to training config
@@ -232,7 +224,6 @@ class Test_Build_Scheduler:
     def test_default_scheduler_building(
         self, model_sample, train_dataset, training_configs_learning_rate
     ):
-
         trainer = BaseTrainer(
             model=model_sample,
             train_dataset=train_dataset,


### PR DESCRIPTION
Helle @AgatheSenellart,

This is a PR adding the following features

## New Features
- Add `AutoModel` and `AutoConfig` instances allowing to reload the models in one line of code from a folder (*e.e.* after training)
```python
from multivae.models import AutoModel
model = AutoModel.load_from_folder("path/to_folder")
```
- Add test bench for model training. In particular, tests were added to test whether a `JMVAE` can be trained properly.

## TODO in future PRs
When adding a new model and new config. We must:
- add the following to `multivae/models/auto_model/auto_config.py`:
```python
elif config_name == "NewModelConfig":
   from ..new_model import NewModelConfig
   model_config = NewModelConfig.from_json_file(json_path)
```
- add the following to `multivae/models/auto_model/auto_model.py`:
```python
elif model_name == "NewModelConfig":
    from ..new_model import NewModel
    model = NewModel.load_from_folder(dir_path=dir_path)