### PR TITLE
fix mmvae_model and test

### DIFF
--- a/src/multivae/data/datasets/base.py
+++ b/src/multivae/data/datasets/base.py
@@ -67,15 +67,31 @@ class IncompleteDataset(MultimodalBaseDataset):
         self.data = data
         self.masks = masks
         self.labels = labels
+        self.check_lenght()
+        
 
-    def __len__(self):
+    def check_lenght(self):
+    
         length = len(self.data[list(self.data)[0]])
+        
+        # check that all modalities have the same number of samples
         for m in self.data:
             if len(self.data[m]) != length or len(self.masks[m]) != length:
                 raise AttributeError(
                     "The size of the provided datasets/masks doesn't correspond between modalities!"
                 )
-
+        # check that labels have the same number of samples
+        if self.labels is not None :
+            if len(self.labels) != length :
+                raise AttributeError(
+                    "The size of the provided datasets/masks doesn't correspond with the labels"
+                )
+        return 
+    
+    def __len__(self):
+    
+        length = len(self.data[list(self.data)[0]])
+        
         return length
 
     def __getitem__(self, index):

--- a/src/multivae/models/mmvae/mmvae_model.py
+++ b/src/multivae/models/mmvae/mmvae_model.py
@@ -132,7 +132,10 @@ class MMVAE(BaseMultiVAE):
             reconstructions[cond_mod] = {}
             for recon_mod in inputs.data:
                 decoder = self.decoders[recon_mod]
-                recon = decoder(z_x)["reconstruction"]
+                # z_x is of shape (K,n_batch, latent_dim), we need to reshape it to make compatible with any decoder
+                z = z_x.reshape(-1, z_x.shape[-1]) # K*n_batch, latent_dim
+                recon = decoder(z)["reconstruction"]
+                recon = recon.reshape((*z_x.shape[:-1], *recon.shape[1:]))
 
                 reconstructions[cond_mod][recon_mod] = recon
 

--- a/tests/test_mmvae_model.py
+++ b/tests/test_mmvae_model.py
@@ -10,14 +10,13 @@ from pythae.models.nn.benchmarks.mnist.convnets import (
     Decoder_Conv_AE_MNIST,
     Encoder_Conv_AE_MNIST,
 )
-from pythae.models.nn.default_architectures import Encoder_VAE_MLP
+from pythae.models.nn.default_architectures import Encoder_VAE_MLP, Decoder_AE_MLP
 from pythae.models.normalizing_flows import IAF, IAFConfig
 from torch import nn
 
 from multivae.data.datasets.base import IncompleteDataset, MultimodalBaseDataset
 from multivae.data.utils import set_inputs_to_device
 from multivae.models import MMVAE, AutoModel, MMVAEConfig
-from multivae.models.nn.default_architectures import Decoder_AE_MLP
 from multivae.trainers import BaseTrainer, BaseTrainerConfig
 
 

--- a/tests/test_mmvae_model.py
+++ b/tests/test_mmvae_model.py
@@ -24,14 +24,14 @@ from multivae.trainers import BaseTrainer, BaseTrainerConfig
 class Test:
     @pytest.fixture(params=["complete", "incomplete"])
     def dataset(self, request):
-        # Create simple small dataset
+        # Create simple small dataset with two multimodal samples
         data = dict(
             mod1=torch.Tensor([[1.0, 2.0], [4.0, 5.0]]),
             mod2=torch.Tensor([[67.1, 2.3, 3.0], [1.3, 2.0, 3.0]]),
             mod3=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
             mod4=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
         )
-        labels = np.array([0, 1, 0, 0])
+        labels = np.array([0, 1])
         if request.param == "complete":
             dataset = MultimodalBaseDataset(data, labels)
         else:
@@ -82,7 +82,7 @@ class Test:
             decoders_dist=dict(
                 mod1="laplace", mod2="laplace", mod3="laplace", mod4="laplace"
             ),
-            decoder_dist_params=dict(mod1={"scale": 0.75}, mod2={"scale": 0.75}),
+            decoder_dist_params=dict(mod1={"scale": 0.75}, mod2={"scale": 0.75})
         )
 
         return model_config
@@ -107,6 +107,8 @@ class Test:
         )
         assert model.K == model_config.K
 
+        # Try forward
+        
         output = model(dataset, epoch=2)
         loss = output.loss
         assert type(loss) == torch.Tensor


### PR DESCRIPTION
The mmvae model was not compatible with certain decoders architectures. 
When the decoder handles only inputs of shape (n_batch, latent_dim), it encountered issues with the MMVAE model providing inputs of size (K,n_batch,latent_dim).

This bug was fixed and the test for MMVAE model was modified to verify it.

Thank you @Saadmohamad for bringing this issue to our attention and @fcaretti for helping in solving it.
