### PR TITLE
IncompleteDataset should work without labels

### DIFF
--- a/src/multivae/data/datasets/base.py
+++ b/src/multivae/data/datasets/base.py
@@ -45,8 +45,7 @@ class MultimodalBaseDataset(Dataset):
         if self.labels is not None:
             y = self.labels[index]
             return DatasetOutput(data=X, labels=y)
-        else:
-            return DatasetOutput(data=X)
+        return DatasetOutput(data=X)
 
     def transform_for_plotting(self, tensor, modality):
         return tensor
@@ -109,7 +108,9 @@ class IncompleteDataset(MultimodalBaseDataset):
         """
         # Select sample
         X = {modality: self.data[modality][index] for modality in self.data}
-        y = self.labels[index] if self.labels is not None else None
         m = {modality: self.masks[modality][index] for modality in self.masks}
 
-        return DatasetOutput(data=X, labels=y, masks=m)
+        if self.labels is not None:
+            y = self.labels[index]
+            return DatasetOutput(data=X, labels=y, masks=m)
+        return DatasetOutput(data=X, masks=m)

--- a/tests/test_moepoe.py
+++ b/tests/test_moepoe.py
@@ -27,9 +27,8 @@ class Test_model:
             mod3=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
             mod4=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
         )
-        labels = np.array([0, 1])
         if request.param == "complete":
-            dataset = MultimodalBaseDataset(data, labels)
+            dataset = MultimodalBaseDataset(data)
         else:
             masks = dict(
                 mod1=torch.Tensor([True, False]),
@@ -37,7 +36,7 @@ class Test_model:
                 mod3=torch.Tensor([True, True]),
                 mod4=torch.Tensor([True, True]),
             )
-            dataset = IncompleteDataset(data=data, masks=masks, labels=labels)
+            dataset = IncompleteDataset(data=data, masks=masks)
 
         return dataset
 
@@ -194,9 +193,8 @@ class Test_backward_with_missing_inputs:
             mod3=torch.randn((6, 4)),
             mod4=torch.randn((6, 4)),
         )
-        labels = np.array([0] * 5 + [1])
         if request.param == "complete":
-            dataset = MultimodalBaseDataset(data, labels)
+            dataset = MultimodalBaseDataset(data)
         else:
             masks = dict(
                 mod1=torch.Tensor([False] * 3 + [True] * 3),
@@ -204,7 +202,7 @@ class Test_backward_with_missing_inputs:
                 mod3=torch.Tensor([True] * 6),
                 mod4=torch.Tensor([True] * 6),
             )
-            dataset = IncompleteDataset(data=data, masks=masks, labels=labels)
+            dataset = IncompleteDataset(data=data, masks=masks)
 
         return dataset
 
@@ -234,7 +232,7 @@ class Test_backward_with_missing_inputs:
             decoders=decoders,
         )
 
-    @pytest.fixture()
+    @pytest.fixture
     def model_config(self, request):
         model_config = MoPoEConfig(
             n_modalities=4,
@@ -285,9 +283,8 @@ class TestTraining:
             mod3=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
             mod4=torch.Tensor([[37, 2, 4, 1], [8, 9, 7, 0]]),
         )
-        labels = np.array([0, 1])
         if request.param == "complete":
-            dataset = MultimodalBaseDataset(data, labels)
+            dataset = MultimodalBaseDataset(data)
         else:
             masks = dict(
                 mod1=torch.Tensor([True, False]),
@@ -295,7 +292,7 @@ class TestTraining:
                 mod3=torch.Tensor([True, True]),
                 mod4=torch.Tensor([True, True]),
             )
-            dataset = IncompleteDataset(data=data, masks=masks, labels=labels)
+            dataset = IncompleteDataset(data=data, masks=masks)
 
         return dataset
 


### PR DESCRIPTION
I removed labels in moepoe tests (which typically does not use them), which raised errors when ran slow. The error happens when collating None values provided to the collate funtion of the loader before the forward pass. I removed labels from the DatasetOutput when it is not available, just as in the MultimodalBaseDataset __getitem__ function.