### PR TITLE
Fix error message of the trainer sanity check

### DIFF
--- a/docs/source/readme.md
+++ b/docs/source/readme.md
@@ -63,23 +63,25 @@ Here is a very simple code to illustrate how you can use MultiVae:
 ```python
 # Load a dataset 
 from multivae.data.datasets import MnistSvhn
-train_set = MnistSvhn(data_path='your_data_path', split="train", download=True)
+
+train_set = MnistSvhn(data_path="./data", split="train", download=True)
 
 
 # Instantiate your favorite model:
 from multivae.models import MVTCAE, MVTCAEConfig
+
 model_config = MVTCAEConfig(
-    latent_dim=20, 
-    input_dims = {'mnist' : (1,28,28),'svhn' : (3,32,32)})
+    n_modalities=2,
+    latent_dim=20,
+    input_dims={"mnist": (1, 28, 28), "svhn": (3, 32, 32)},
+)
 model = MVTCAE(model_config)
 
 
 # Define a trainer and train the model !
 from multivae.trainers import BaseTrainer, BaseTrainerConfig
-training_config = BaseTrainerConfig(
-    learning_rate=1e-3,
-    num_epochs=30
-)
+
+training_config = BaseTrainerConfig(learning_rate=1e-3, num_epochs=10)
 
 trainer = BaseTrainer(
     model=model,

--- a/src/multivae/models/mvae/mvae_model.py
+++ b/src/multivae/models/mvae/mvae_model.py
@@ -150,7 +150,7 @@ class MVAE(BaseMultiVAE):
 
         epoch = kwargs.pop("epoch", 1)
         # The annealing factor is updated each batch, so we need to know the idx of the batch in the epoch
-        batch_ratio = kwargs.pop("batch_ratio", 0) 
+        batch_ratio = kwargs.pop("batch_ratio", 0)
         if epoch >= self.warmup:
             beta = 1 * self.beta
         else:
@@ -195,10 +195,10 @@ class MVAE(BaseMultiVAE):
                 metrics["recon" + "_".join(sorted(s))] = subset_recon
             else:
                 subset_elbo = subset_kld = subset_recon = torch.tensor(
-                    0.0, requires_grad=True)
+                    0.0, requires_grad=True
+                )
                 len_batch = 0.0
             total_loss += subset_elbo
-            
 
         return ModelOutput(
             loss=total_loss, loss_sum=total_loss * len_batch, metrics=metrics

--- a/src/multivae/models/mvae/mvae_model.py
+++ b/src/multivae/models/mvae/mvae_model.py
@@ -149,7 +149,8 @@ class MVAE(BaseMultiVAE):
         """
 
         epoch = kwargs.pop("epoch", 1)
-        batch_ratio = kwargs.pop("batch_ratio", 0)
+        # The annealing factor is updated each batch, so we need to know the idx of the batch in the epoch
+        batch_ratio = kwargs.pop("batch_ratio", 0) 
         if epoch >= self.warmup:
             beta = 1 * self.beta
         else:
@@ -186,13 +187,18 @@ class MVAE(BaseMultiVAE):
                     subset_recon,
                     len_batch,
                 ) = self._compute_elbo_subset(filtered_inputs, s, beta)
+
+                # update the metrics for monitoring
+                metrics["_".join(sorted(s))] = subset_elbo
+                metrics["beta"] = beta
+                metrics["kld" + "_".join(sorted(s))] = subset_kld
+                metrics["recon" + "_".join(sorted(s))] = subset_recon
             else:
-                subset_elbo = subset_kld = subset_recon = 0
+                subset_elbo = subset_kld = subset_recon = torch.tensor(
+                    0.0, requires_grad=True)
+                len_batch = 0.0
             total_loss += subset_elbo
-            metrics["_".join(sorted(s))] = subset_elbo
-            metrics["beta"] = beta
-            metrics["kld" + "_".join(sorted(s))] = subset_kld
-            metrics["recon" + "_".join(sorted(s))] = subset_recon
+            
 
         return ModelOutput(
             loss=total_loss, loss_sum=total_loss * len_batch, metrics=metrics

--- a/src/multivae/trainers/base/base_trainer.py
+++ b/src/multivae/trainers/base/base_trainer.py
@@ -335,14 +335,16 @@ class BaseTrainer:
         except Exception as e:
             raise Exception(
                 "Error when calling forward method from model. Potential issues: \n"
-                " - Wrong model architecture -> check encoders, decoders and other custom architectures that "
-                "you provided. \n"
-                " - The input_dims that you provided might be wrong -> when no encoders or decoders are "
-                "provided, networks are built automatically but requires the data shape for each modality.\n"
-                "Check the input_dims parameter in the model config. It must be a dictionary with a tuple shape"
-                " for each modality.\n"
-                " - The model might not be compatible with the dataset you provided. \n"
-                f"This is the specific exception raised: {type(e)} with message: " + str(e)
+                " - Wrong model architecture:\n"
+                "   Check encoders, decoders, and other custom architectures that you provided.\n"
+                " - Incorrect input_dims:\n"
+                "   When no encoders or decoders are provided, networks are built automatically but require\n"
+                "   the data shape for each modality. Check the input_dims parameter in the model config.\n"
+                "   It must be a dictionary with a tuple shape for each modality.\n"
+                " - Dataset incompatibility:\n"
+                "   The model might not be compatible with the dataset you provided.\n"
+                f"This is the specific exception raised: {type(e)} with message: "
+                + str(e)
             ) from e
 
     def _optimizers_step(self, model_output=None):

--- a/src/multivae/trainers/base/base_trainer.py
+++ b/src/multivae/trainers/base/base_trainer.py
@@ -335,12 +335,14 @@ class BaseTrainer:
         except Exception as e:
             raise Exception(
                 "Error when calling forward method from model. Potential issues: \n"
-                " - Wrong model architecture -> check encoder, decoder and metric architecture if "
-                "you provide yours \n"
-                " - The data input dimension provided is wrong -> when no encoder, decoder or metric "
-                "provided, a network is built automatically but requires the shape of the flatten "
-                "input data.\n"
-                f"Exception raised: {type(e)} with message: " + str(e)
+                " - Wrong model architecture -> check encoders, decoders and other custom architectures that "
+                "you provided. \n"
+                " - The input_dims that you provided might be wrong -> when no encoders or decoders are "
+                "provided, networks are built automatically but requires the data shape for each modality.\n"
+                "Check the input_dims parameter in the model config. It must be a dictionary with a tuple shape"
+                " for each modality.\n"
+                " - The model might not be compatible with the dataset you provided. \n"
+                f"This is the specific exception raised: {type(e)} with message: " + str(e)
             ) from e
 
     def _optimizers_step(self, model_output=None):

--- a/tests/test_basemodel.py
+++ b/tests/test_basemodel.py
@@ -138,7 +138,6 @@ class Test_BaseMultiVAE:
         with pytest.raises(KeyError):
             BaseMultiVAE(model_config, encoders=encoders, decoders=decoders)
 
-
     def test_recon_dist(self):
         model_config = BaseMultiVAEConfig(
             n_modalities=4,


### PR DESCRIPTION
This PR contains the following changes:

- We update the quickstart example in the online documentation in addition to the README
- We added a small fix in the MVAE model making it robust to empty batches within an incomplete dataset
- We updated the error message in the sanity check of the BaseTrainer to be more helpful during debugging 